### PR TITLE
Add prototype USD viewer

### DIFF
--- a/prototype-viewer/README.md
+++ b/prototype-viewer/README.md
@@ -1,0 +1,32 @@
+# Prototype IFC5 USD Viewer
+
+This folder contains a proof-of-concept for converting IFC5 `.ifcx` files to USD format and
+viewing the result with Three.js using the TinyUSDZ loader.
+
+## Usage
+
+1. Convert an `.ifcx` file to `.usda`:
+
+```sh
+node convert.js "../Hello Wall/hello-wall.ifcx" hellowall.usda
+```
+
+Package the resulting `hellowall.usda` into a `hellowall.usdz` archive and place it
+next to `index.html` (not included here).
+
+2. Open `public/index.html` in a browser with a local server to load the USDZ file.
+
+The viewer relies on TinyUSDZ's experimental `TinyUSDZLoader` which is not
+included in this repository. Obtain it from the TinyUSDZ project and place the
+loader script next to `index.html`.
+
+## Tests
+
+Run the tests with Node:
+
+```sh
+node test/convert.test.js
+```
+
+The tests verify that the conversion step outputs a basic USDA structure for the
+Hello Wall example.

--- a/prototype-viewer/convert.js
+++ b/prototype-viewer/convert.js
@@ -1,0 +1,57 @@
+const fs = require('fs');
+const path = require('path');
+
+function convertIfcxToUsda(ifcx) {
+  let lines = ['#usda 1.0'];
+  const nodes = new Map();
+  ifcx.data.forEach(entry => {
+    nodes.set(entry.path, entry);
+  });
+
+  // Build prims
+  ifcx.data.forEach(entry => {
+    const primType = getPrimType(entry);
+    const name = sanitizeName(entry.path);
+    lines.push(`def ${primType} \"${name}\" {`);
+    if (entry.attributes && entry.attributes['usd::usdgeom::mesh']) {
+      const mesh = entry.attributes['usd::usdgeom::mesh'];
+      if (mesh.faceVertexIndices) {
+        lines.push(`  int[] faceVertexIndices = [${mesh.faceVertexIndices.join(', ')}]`);
+      }
+      if (mesh.points) {
+        const pts = mesh.points.map(p => `(${p.join(', ')})`).join(', ');
+        lines.push(`  point3f[] points = [${pts}]`);
+      }
+    }
+    lines.push('}');
+  });
+  return lines.join('\n');
+}
+
+function sanitizeName(name) {
+  return name.replace(/[^a-zA-Z0-9_]/g, '_');
+}
+
+function getPrimType(entry) {
+  if (entry.attributes && entry.attributes['usd::usdgeom::mesh']) {
+    return 'UsdGeom\:Mesh';
+  }
+  if (entry.attributes && entry.attributes['usd::usdgeom::basiscurves']) {
+    return 'UsdGeom\:BasisCurves';
+  }
+  return 'Xform';
+}
+
+module.exports = { convertIfcxToUsda };
+
+if (require.main === module) {
+  const [,, inputPath, outputPath] = process.argv;
+  if (!inputPath || !outputPath) {
+    console.error('Usage: node convert.js input.ifcx output.usda');
+    process.exit(1);
+  }
+  const data = JSON.parse(fs.readFileSync(inputPath, 'utf8'));
+  const usda = convertIfcxToUsda(data);
+  fs.writeFileSync(outputPath, usda);
+  console.log(`Wrote ${outputPath}`);
+}

--- a/prototype-viewer/public/index.html
+++ b/prototype-viewer/public/index.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<title>IFC5 USD Viewer</title>
+<script type="module">
+import * as THREE from 'https://unpkg.com/three@0.171.0/build/three.module.js';
+import { OrbitControls } from 'https://unpkg.com/three@0.171.0/examples/jsm/controls/OrbitControls.js';
+// TinyUSDZLoader.js should be provided from TinyUSDZ project
+import { TinyUSDZLoader } from './TinyUSDZLoader.js';
+
+const scene = new THREE.Scene();
+const camera = new THREE.PerspectiveCamera(60, window.innerWidth/window.innerHeight, 0.1, 1000);
+camera.position.set(5,5,5);
+const renderer = new THREE.WebGLRenderer({antialias:true});
+renderer.setSize(window.innerWidth, window.innerHeight);
+document.body.appendChild(renderer.domElement);
+
+const controls = new OrbitControls(camera, renderer.domElement);
+controls.update();
+
+const loader = new TinyUSDZLoader();
+loader.load('hellowall.usdz', obj => {
+  scene.add(obj);
+  renderer.setAnimationLoop(() => {
+    controls.update();
+    renderer.render(scene, camera);
+  });
+});
+</script>
+</head>
+<body>
+</body>
+</html>

--- a/prototype-viewer/test/convert.test.js
+++ b/prototype-viewer/test/convert.test.js
@@ -1,0 +1,23 @@
+const assert = require('assert');
+const fs = require('fs');
+const path = require('path');
+const { convertIfcxToUsda } = require('../convert');
+
+function testConvertHelloWall() {
+  const ifcxPath = path.resolve(__dirname, '../../Hello Wall/hello-wall.ifcx');
+  const data = JSON.parse(fs.readFileSync(ifcxPath, 'utf8'));
+  const usda = convertIfcxToUsda(data);
+  assert.ok(usda.startsWith('#usda 1.0'), 'should start with USDA header');
+  assert.ok(usda.includes('def'), 'should contain a def statement');
+  assert.ok(/UsdGeom:Mesh/.test(usda), 'should contain mesh prim');
+  console.log('✓ convert Hello Wall example');
+}
+
+try {
+  testConvertHelloWall();
+  console.log('All tests passed');
+} catch (e) {
+  console.error('Test failed');
+  console.error(e);
+  process.exit(1);
+}


### PR DESCRIPTION
## Summary
- add a small prototype to convert IFCX to USDA and HTML viewer
- include a simple Node-based test

## Testing
- `node prototype-viewer/test/convert.test.js`


------
https://chatgpt.com/codex/tasks/task_e_683c5726124c832085bae2ec6302089a

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a proof-of-concept toolchain for converting IFC5 `.ifcx` files to USD format and viewing them in the browser using Three.js and TinyUSDZ.
  - Added a basic 3D viewer for USDZ files with interactive camera controls.
- **Documentation**
  - Added a README with setup, usage, and testing instructions.
- **Tests**
  - Added automated tests to verify the IFCX-to-USDA conversion process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->